### PR TITLE
chore: migrate from JitPack to Labs64 Nexus

### DIFF
--- a/auditflow-be/pom.xml
+++ b/auditflow-be/pom.xml
@@ -39,12 +39,7 @@
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
-    </repositories>
+
 
     <dependencyManagement>
         <dependencies>
@@ -102,11 +97,11 @@
         </dependency>
 
         <!-- Trusted gateway auth-context: X-Auth-* parsing, fail-closed
-             enforcement and propagation. Served by JitPack from Labs64/labs64.io-commons. -->
+             enforcement and propagation. Served by Labs64 Nexus. -->
         <dependency>
-            <groupId>com.github.Labs64.labs64.io-commons</groupId>
+            <groupId>io.labs64</groupId>
             <artifactId>l64-auth-context-spring-boot-starter</artifactId>
-            <version>v0.1.0</version>
+            <version>0.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Updates dependency to use io.labs64:l64-auth-context-spring-boot-starter:0.1.1 from Nexus, removing JitPack.