### PR TITLE
Add pip ecosystem to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,15 @@ updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
-      interval: "weekly" 
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/auditflow-transformer"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/auditflow-sink"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- `dependabot.yml` had no `pip` entry, so `auditflow-transformer/` and `auditflow-sink/` (Python/FastAPI) got Dependabot vulnerability *alerts* but no scheduled version-update PRs, unlike the Java (`maven`) side.
- Adds `pip` entries for both directories, matching the existing `weekly` cadence.

## Test plan
- [ ] Merge and confirm Dependabot opens/queues update PRs for `auditflow-transformer`/`auditflow-sink` `requirements*.txt`

https://claude.ai/code/session_01W7KQDkNYDZQmvLqnUmF1jM