### PR TITLE
feat(api): add request-scoped headers to AuditFlow client

### DIFF
--- a/auditflow-api/README.md
+++ b/auditflow-api/README.md
@@ -50,6 +50,13 @@ AuditEvent event = AuditEvents.builder("user.login")
 // Synchronous — throws a typed AuditFlowException on failure
 PublishResult result = client.publish(event);
 
+// Request-scoped headers, for example for a direct internal call
+PublishResult internalResult = client.publish(event,
+        AuditFlowRequestOptions.builder()
+                .headers(internalCallHeaders)
+                .build());
+
+
 // Asynchronous — non-blocking
 client.publishAsync(event).thenAccept(r -> System.out.println(r.eventId()));
 

--- a/auditflow-api/src/main/java/io/labs64/auditflow/client/AuditFlowClient.java
+++ b/auditflow-api/src/main/java/io/labs64/auditflow/client/AuditFlowClient.java
@@ -21,11 +21,20 @@ public interface AuditFlowClient {
     /** Publishes synchronously, throwing a typed {@link io.labs64.auditflow.client.exception.AuditFlowException} on failure. */
     PublishResult publish(AuditEvent event);
 
+    /** Publishes synchronously with options scoped to this request. */
+    PublishResult publish(AuditEvent event, AuditFlowRequestOptions options);
+
     /** Publishes without blocking; the future completes exceptionally on failure. */
     CompletableFuture<PublishResult> publishAsync(AuditEvent event);
 
+    /** Publishes without blocking with options scoped to this request. */
+    CompletableFuture<PublishResult> publishAsync(AuditEvent event, AuditFlowRequestOptions options);
+
     /** Publishes without blocking and never throws into the caller; failures go to the configured error handler. */
     void fireAndForget(AuditEvent event);
+
+    /** Publishes without blocking with options scoped to this request. */
+    void fireAndForget(AuditEvent event, AuditFlowRequestOptions options);
 
     static Builder builder() {
         return new Builder();

--- a/auditflow-api/src/main/java/io/labs64/auditflow/client/AuditFlowRequestOptions.java
+++ b/auditflow-api/src/main/java/io/labs64/auditflow/client/AuditFlowRequestOptions.java
@@ -1,0 +1,52 @@
+package io.labs64.auditflow.client;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/** Options applied to one AuditFlow request. */
+public final class AuditFlowRequestOptions {
+
+    private static final AuditFlowRequestOptions EMPTY = new AuditFlowRequestOptions(Map.of());
+
+    private final Map<String, String> headers;
+
+    private AuditFlowRequestOptions(final Map<String, String> headers) {
+        this.headers = Map.copyOf(headers);
+    }
+
+    public static AuditFlowRequestOptions empty() {
+        return EMPTY;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Map<String, String> headers() {
+        return headers;
+    }
+
+    public static final class Builder {
+
+        private final Map<String, String> headers = new LinkedHashMap<>();
+
+        private Builder() {
+        }
+
+        public Builder headers(final Map<String, String> headers) {
+            this.headers.clear();
+            this.headers.putAll(Objects.requireNonNull(headers, "headers"));
+            return this;
+        }
+
+        public Builder header(final String name, final String value) {
+            this.headers.put(Objects.requireNonNull(name, "name"), Objects.requireNonNull(value, "value"));
+            return this;
+        }
+
+        public AuditFlowRequestOptions build() {
+            return headers.isEmpty() ? EMPTY : new AuditFlowRequestOptions(headers);
+        }
+    }
+}

--- a/auditflow-api/src/main/java/io/labs64/auditflow/client/DefaultAuditFlowClient.java
+++ b/auditflow-api/src/main/java/io/labs64/auditflow/client/DefaultAuditFlowClient.java
@@ -38,8 +38,13 @@ final class DefaultAuditFlowClient implements AuditFlowClient {
 
     @Override
     public PublishResult publish(AuditEvent event) {
+        return publish(event, AuditFlowRequestOptions.empty());
+    }
+
+    @Override
+    public PublishResult publish(AuditEvent event, AuditFlowRequestOptions options) {
         try {
-            return publishAsync(event).join();
+            return publishAsync(event, options).join();
         } catch (CompletionException e) {
             Throwable cause = e.getCause();
             if (cause instanceof AuditFlowException) {
@@ -54,8 +59,13 @@ final class DefaultAuditFlowClient implements AuditFlowClient {
 
     @Override
     public CompletableFuture<PublishResult> publishAsync(AuditEvent event) {
+        return publishAsync(event, AuditFlowRequestOptions.empty());
+    }
+
+    @Override
+    public CompletableFuture<PublishResult> publishAsync(AuditEvent event, AuditFlowRequestOptions options) {
         AuditEvent prepared = prepare(event);
-        HttpRequest request = buildRequest(prepared);
+        HttpRequest request = buildRequest(prepared, options != null ? options : AuditFlowRequestOptions.empty());
         return sendAsyncWithRetry(request, 1);
     }
 
@@ -98,7 +108,12 @@ final class DefaultAuditFlowClient implements AuditFlowClient {
 
     @Override
     public void fireAndForget(AuditEvent event) {
-        publishAsync(event).whenComplete((result, error) -> {
+        fireAndForget(event, AuditFlowRequestOptions.empty());
+    }
+
+    @Override
+    public void fireAndForget(AuditEvent event, AuditFlowRequestOptions options) {
+        publishAsync(event, options).whenComplete((result, error) -> {
             if (error != null) {
                 Throwable cause = error instanceof CompletionException && error.getCause() != null
                         ? error.getCause() : error;
@@ -127,18 +142,19 @@ final class DefaultAuditFlowClient implements AuditFlowClient {
         return event;
     }
 
-    private HttpRequest buildRequest(AuditEvent event) {
+    private HttpRequest buildRequest(AuditEvent event, AuditFlowRequestOptions options) {
         String json = serialize(event);
         HttpRequest.Builder builder = HttpRequest.newBuilder(publishUri)
                 .timeout(config.requestTimeout())
-                .header("Content-Type", "application/json")
-                .header("Accept", "application/json")
-                .header("X-Correlation-ID", event.getCorrelationId())
                 .POST(HttpRequest.BodyPublishers.ofString(json));
+        options.headers().forEach(builder::setHeader);
+        builder.setHeader("Content-Type", "application/json");
+        builder.setHeader("Accept", "application/json");
+        builder.setHeader("X-Correlation-ID", event.getCorrelationId());
         if (config.tokenProvider() != null) {
             String token = config.tokenProvider().token();
             if (token != null && !token.isBlank()) {
-                builder.header("Authorization", "Bearer " + token);
+                builder.setHeader("Authorization", "Bearer " + token);
             }
         }
         return builder.build();

--- a/auditflow-api/src/main/java/io/labs64/auditflow/client/DefaultAuditFlowClient.java
+++ b/auditflow-api/src/main/java/io/labs64/auditflow/client/DefaultAuditFlowClient.java
@@ -113,7 +113,7 @@ final class DefaultAuditFlowClient implements AuditFlowClient {
 
     @Override
     public void fireAndForget(AuditEvent event, AuditFlowRequestOptions options) {
-        publishAsync(event, options).whenComplete((result, error) -> {
+        publishAsync(event, options).whenComplete((ignoredResult, error) -> {
             if (error != null) {
                 Throwable cause = error instanceof CompletionException && error.getCause() != null
                         ? error.getCause() : error;

--- a/auditflow-api/src/test/java/io/labs64/auditflow/client/DefaultAuditFlowClientPublishTest.java
+++ b/auditflow-api/src/test/java/io/labs64/auditflow/client/DefaultAuditFlowClientPublishTest.java
@@ -58,6 +58,60 @@ class DefaultAuditFlowClientPublishTest {
     }
 
     @Test
+    void publishAppliesRequestHeadersWithoutToken() {
+        server.enqueue(CannedResponse.ok(Map.of()));
+        AuditFlowClient client = AuditFlowClient.builder()
+                .baseUrl(server.baseUrl())
+                .build();
+
+        client.publish(
+                new AuditEvent().eventType("payment.created"),
+                AuditFlowRequestOptions.builder()
+                        .headers(Map.of("X-Auth-User", "svc:payment-gateway"))
+                        .build());
+
+        assertEquals(
+                List.of("svc:payment-gateway"),
+                header(server.lastRequest().headers(), "X-Auth-User"));
+    }
+
+    @Test
+    void tokenProviderOverridesRequestAuthorizationHeader() {
+        server.enqueue(CannedResponse.ok(Map.of()));
+
+        client().publish(
+                new AuditEvent().eventType("payment.created"),
+                AuditFlowRequestOptions.builder()
+                        .header("Authorization", "Custom value")
+                        .build());
+
+        assertEquals(
+                List.of("Bearer jwt-123"),
+                header(server.lastRequest().headers(), "Authorization"));
+    }
+
+    @Test
+    void eventCorrelationIdOverridesRequestHeader() {
+        server.enqueue(CannedResponse.ok(Map.of()));
+        AuditFlowClient client = AuditFlowClient.builder()
+                .baseUrl(server.baseUrl())
+                .build();
+        AuditEvent event = new AuditEvent()
+                .eventType("payment.created")
+                .correlationId("event-correlation");
+
+        client.publish(
+                event,
+                AuditFlowRequestOptions.builder()
+                        .header("X-Correlation-ID", "options-correlation")
+                        .build());
+
+        assertEquals(
+                List.of("event-correlation"),
+                header(server.lastRequest().headers(), "X-Correlation-ID"));
+    }
+
+    @Test
     void publishUsesCorrelationIdProvider() {
         server.enqueue(CannedResponse.ok(Map.of()));
         AuditFlowClient client = AuditFlowClient.builder()
@@ -123,4 +177,11 @@ class DefaultAuditFlowClientPublishTest {
         assertEquals(3, server.requestCount());
     }
 
+    private static List<String> header(Map<String, List<String>> headers, String name) {
+        return headers.entrySet().stream()
+                .filter(entry -> entry.getKey().equalsIgnoreCase(name))
+                .map(Map.Entry::getValue)
+                .findFirst()
+                .orElse(null);
+    }
 }


### PR DESCRIPTION
## Summary

Add support for direct authenticated service-to-service API calls and migrate Payment Gateway audit publishing from the gateway/OAuth2 client-credentials flow to the internal AuditFlow Kubernetes service.

## Related
- https://github.com/Labs64/labs64.io-workspace/pull/8
- https://github.com/Labs64/labs64.io-commons/pull/19
- https://github.com/Labs64/labs64.io-payment-gateway/pull/36
- https://github.com/Labs64/labs64.io-helm-charts/pull/16