### PR TITLE
Standardize Python runtime images on Python 3.13 slim

### DIFF
--- a/auditflow-sink/Dockerfile
+++ b/auditflow-sink/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-alpine
+FROM python:3.13-slim
 
 ARG GIT_REVISION=unknown
 
@@ -17,8 +17,8 @@ ARG USER_NAME=l64user
 ARG GROUP_NAME=l64group
 
 # Create group and user with the specified IDs
-RUN addgroup -g ${GROUP_ID} ${GROUP_NAME} && \
-    adduser -D -u ${USER_ID} -G ${GROUP_NAME} ${USER_NAME}
+RUN groupadd -g ${GROUP_ID} ${GROUP_NAME} && \
+    useradd -m -u ${USER_ID} -g ${GROUP_NAME} ${USER_NAME}
 
 # Set working directory
 WORKDIR /home/${USER_NAME}
@@ -58,7 +58,7 @@ EXPOSE 8082
 USER ${USER_NAME}
 
 HEALTHCHECK --interval=10s --timeout=5s --start-period=15s --retries=3 \
-    CMD wget -qO- http://127.0.0.1:8082/sinks || exit 1
+    CMD python -c "import urllib.request;urllib.request.urlopen('http://127.0.0.1:8082/registry', timeout=4)" || exit 1
 
 # entrypoint.sh enables OTel auto-instrumentation iff OTEL_EXPORTER_OTLP_ENDPOINT is set
 ENTRYPOINT ["./entrypoint.sh"]

--- a/auditflow-transformer/Dockerfile
+++ b/auditflow-transformer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-alpine
+FROM python:3.13-slim
 
 ARG GIT_REVISION=unknown
 
@@ -17,8 +17,8 @@ ARG USER_NAME=l64user
 ARG GROUP_NAME=l64group
 
 # Create group and user with the specified IDs
-RUN addgroup -g ${GROUP_ID} ${GROUP_NAME} && \
-    adduser -D -u ${USER_ID} -G ${GROUP_NAME} ${USER_NAME}
+RUN groupadd -g ${GROUP_ID} ${GROUP_NAME} && \
+    useradd -m -u ${USER_ID} -g ${GROUP_NAME} ${USER_NAME}
 
 # Set working directory
 WORKDIR /home/${USER_NAME}
@@ -58,7 +58,7 @@ EXPOSE 8081
 USER ${USER_NAME}
 
 HEALTHCHECK --interval=10s --timeout=5s --start-period=15s --retries=3 \
-    CMD wget -qO- http://127.0.0.1:8081/transformers || exit 1
+    CMD python -c "import urllib.request;urllib.request.urlopen('http://127.0.0.1:8081/registry', timeout=4)" || exit 1
 
 # entrypoint.sh enables OTel auto-instrumentation iff OTEL_EXPORTER_OTLP_ENDPOINT is set
 ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
## Why

AuditFlow's transformer and sink images used `python:3.14-alpine`, while the ecosystem standard, CI environment, shared Python package, and documentation target Python 3.13.

Using `python:3.13-slim` provides a consistent Python baseline across Labs64.IO services and better compatibility with prebuilt native wheels such as psycopg, cryptography, and OpenTelemetry dependencies. It also allows the Python services to share the same base image layers.

